### PR TITLE
Fixing 5160 dimensions

### DIFF
--- a/PdfLabel.php
+++ b/PdfLabel.php
@@ -110,7 +110,7 @@ class PdfLabel extends \TCPDF
      */
     const LABELS = array(
         '5160' => array(
-            'paper-size' => 'letter',
+            'paper-size' => 'LETTER',
             'unit' => 'mm',
             'marginLeft' => 1.762,
             'marginTop' => 10.7,
@@ -122,7 +122,7 @@ class PdfLabel extends \TCPDF
             'height' => 25.4
         ),
         '5161' => array(
-            'paper-size' => 'letter',
+            'paper-size' => 'LETTER',
             'unit' => 'mm',
             'marginLeft' => 0.967,
             'marginTop' => 10.7,
@@ -134,7 +134,7 @@ class PdfLabel extends \TCPDF
             'height' => 25.4
         ),
         '5162' => array(
-            'paper-size' => 'letter',
+            'paper-size' => 'LETTER',
             'unit' => 'mm',
             'marginLeft' => 0.97,
             'marginTop' => 20.224,
@@ -146,7 +146,7 @@ class PdfLabel extends \TCPDF
             'height' => 35.72
         ),
         '5163' => array(
-            'paper-size' => 'letter',
+            'paper-size' => 'LETTER',
             'unit' => 'mm',
             'marginLeft' => 1.762,
             'marginTop' => 10.7,
@@ -158,7 +158,7 @@ class PdfLabel extends \TCPDF
             'height' => 50.8
         ),
         '5164' => array(
-            'paper-size' => 'letter',
+            'paper-size' => 'LETTER',
             'unit' => 'in',
             'marginLeft' => 0.148,
             'marginTop' => 0.5,
@@ -170,7 +170,7 @@ class PdfLabel extends \TCPDF
             'height' => 3.33
         ),
         '8600' => array(
-            'paper-size' => 'letter',
+            'paper-size' => 'LETTER',
             'unit' => 'mm',
             'marginLeft' => 7.1,
             'marginTop' => 19,

--- a/PdfLabel.php
+++ b/PdfLabel.php
@@ -112,8 +112,8 @@ class PdfLabel extends \TCPDF
         '5160' => array(
             'paper-size' => 'LETTER',
             'unit' => 'mm',
-            'marginLeft' => 1.762,
-            'marginTop' => 10.7,
+            'marginLeft' => 4.7625,
+            'marginTop' => 12.7,
             'NX' => 3,
             'NY' => 10,
             'SpaceX' => 3.175,


### PR DESCRIPTION
The paper-size variable must be uppercase LETTER or USLETTER or else TCPDF will default to A4.

Dimensions for 5160 were apparently wrong. Appear to have been pulled from http://www.fpdf.org/en/script/script29.php however I believe I have corrected them and it appears to be working properly like this. 